### PR TITLE
Margins now properly scale, keeping content at a constant 1152px (fol…

### DIFF
--- a/components/HomeFilters/FilterButtonRow.tsx
+++ b/components/HomeFilters/FilterButtonRow.tsx
@@ -12,9 +12,16 @@ const FilterButtonRow__wrapper = styled.div`
     background-color: var(--primary-white);
     position: sticky;
     top: 64px;
-    padding: 0 320px;
     border-bottom: 1px solid var(--primary-gray);
     z-index: 1;
+`;
+
+const FilterButtonRow__resizer = styled.div`
+    // TODO: responsive styling for smaller screens. Currently drafting at device width = 1800px
+    
+    width: 1152px;
+    margin-left: auto;
+    margin-right: auto;
 `;
 
 const FilterButtonRow__list = styled.ul`
@@ -73,18 +80,20 @@ export default function FilterButtonRow() {
     
     return (
         <FilterButtonRow__wrapper>
-            <FilterButtonRow__list>
-                {
-                    filterButtonData.map(buttonData => {
-                        return (
-                            <FilterButton 
-                                buttonData={buttonData} 
-                                key={buttonData.buttonLabel}
-                            />
-                        )
-                    })
-                }
-            </FilterButtonRow__list>
+            <FilterButtonRow__resizer>
+                <FilterButtonRow__list>
+                    {
+                        filterButtonData.map(buttonData => {
+                            return (
+                                <FilterButton
+                                    buttonData={buttonData}
+                                    key={buttonData.buttonLabel}
+                                />
+                            )
+                        })
+                    }
+                </FilterButtonRow__list>
+            </FilterButtonRow__resizer>
         </FilterButtonRow__wrapper>
     );
 }

--- a/components/RestaurantCarousel/RestaurantCarousel.tsx
+++ b/components/RestaurantCarousel/RestaurantCarousel.tsx
@@ -5,8 +5,11 @@ import RestaurantCard from "./RestaurantCard/RestaurantCard";
 const RestaurantCarousel__article = styled.article`
     display: flex;
     flex-direction: column;
-    margin: 19px 0;
+    margin: 19px auto;
     row-gap: 19px;
+
+    // TODO: responsive styling for smaller screens. Currently drafting at device width = 1800px
+    width: 1152px;
 `;
 
 const RestaurantCarousel__topRow = styled.div`

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,6 @@ import data from "../components/data";
 
 const RestaurantCarouselSection = styled.section`
     width: 100%;
-    padding: 0 320px;
 `;
 
 export default function Home() {


### PR DESCRIPTION
…lowing doordash)

# Changes

In order to follow DoorDash's horizontal window resizing, we need to utilize `margin-left: auto` and `margin-right: auto` on our content components, namely `<FilterButtonRow />` and `<RestaurantCarousel />`.

By adding a resizer class on the `<FilterButtonRow />` component, we can restrict horizontal width to a specified width and let `margin: auto` do the remaining work on centering the component. Ideally, we would have just used flexbox to center this item.

We need to specify widths for other breakpoints, namely when width drops below `1152px`, the width of the container - We will need to begin resizing content based components, like <RestaurantCard />